### PR TITLE
Allow to tune resources of all containers of controller pod, fix values usage

### DIFF
--- a/wallarm-ingress/templates/_helpers.tpl
+++ b/wallarm-ingress/templates/_helpers.tpl
@@ -124,7 +124,7 @@ Create the name of the service account to use
   securityContext:
     runAsUser: 0
   resources:
-{{ toYaml .Values.controller.resources | indent 4 }}
+{{ toYaml .Values.controller.wallarm.synccloud.resources | indent 4 }}
 {{- end -}}
 
 {{- define "nginx-ingress.wallarmCollectdContainer" -}}
@@ -138,5 +138,5 @@ Create the name of the service account to use
     - name: collectd-config
       mountPath: /etc/collectd
   resources:
-{{ toYaml .Values.controller.resources | indent 4 }}
+{{ toYaml .Values.controller.wallarm.collectd.resources | indent 4 }}
 {{- end -}}


### PR DESCRIPTION
Resources definitions for collectd and synccloud containers was added in values.yaml, but in _helpers.tpl for this containers used resources from nginx container. Fix #1 .