### PR TITLE
Define resources for all containers containers in wallarm-tarantool pod

### DIFF
--- a/wallarm-ingress/templates/tarantool-daemonset.yaml
+++ b/wallarm-ingress/templates/tarantool-daemonset.yaml
@@ -73,42 +73,56 @@ spec:
           volumeMounts:
           - mountPath: /etc/wallarm
             name: wallarm
+          resources:
+{{ toYaml .Values.controller.wallarm.heartbeat.resources | indent 12 }}
         - name: sync-markers
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
           command: ["sh", "-c", "while true; do timeout -k 1m 1h /usr/share/wallarm-common/sync-markers -l STDOUT || true; sleep 60; done"]
           volumeMounts:
           - mountPath: /etc/wallarm
             name: wallarm
+          resources:
+{{ toYaml .Values.controller.wallarm.sync-markers.resources | indent 12 }}
         - name: export-attacks
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
           command: ["sh", "-c", "while true; do timeout -k 1m 3h /usr/share/wallarm-common/export-attacks -l STDOUT || true; done"]
           volumeMounts:
           - mountPath: /etc/wallarm
             name: wallarm
+          resources:
+{{ toYaml .Values.controller.wallarm.export-attacks.resources | indent 12 }}
         - name: export-counters
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
           command: ["sh", "-c", "while true; do timeout -k 15s 11m /usr/share/wallarm-common/export-counters -l STDOUT || true; sleep 60; done"]
           volumeMounts:
           - mountPath: /etc/wallarm
             name: wallarm
+          resources:
+{{ toYaml .Values.controller.wallarm.export-counters.resources | indent 12 }}
         - name: export-clusterization-data
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
           command: ["sh", "-c", "while true; do timeout -k 15s 11m /usr/share/wallarm-common/export-clusterization-data -l STDOUT || true; sleep 60; done"]
           volumeMounts:
           - mountPath: /etc/wallarm
             name: wallarm
+          resources:
+{{ toYaml .Values.controller.wallarm.export-clusterization-data.resources | indent 12 }}
         - name: sync-brute-clusters
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
           command: ["sh", "-c", "while true; do timeout -k 15s 11m /usr/share/wallarm-common/sync-brute-clusters -l STDOUT || true; sleep 60; done"]
           volumeMounts:
           - mountPath: /etc/wallarm
             name: wallarm
+          resources:
+{{ toYaml .Values.controller.wallarm.sync-brute-clusters.resources | indent 12 }}
         - name: brute-detect
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
           command: ["sh", "-c", "while true; do timeout -k 15s 6m /usr/share/wallarm-common/brute-detect -l STDOUT || true; sleep 60; done"]
           volumeMounts:
           - mountPath: /etc/wallarm
             name: wallarm
+          resources:
+{{ toYaml .Values.controller.wallarm.brute-detect.resources | indent 12 }}
     {{- if .Values.controller.wallarm.tarantool.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.controller.wallarm.tarantool.nodeSelector | indent 8 }}

--- a/wallarm-ingress/templates/tarantool-deployment.yaml
+++ b/wallarm-ingress/templates/tarantool-deployment.yaml
@@ -78,42 +78,56 @@ spec:
           volumeMounts:
           - mountPath: /etc/wallarm
             name: wallarm
+          resources:
+{{ toYaml .Values.controller.wallarm.heartbeat.resources | indent 12 }}
         - name: sync-markers
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
           command: ["sh", "-c", "while true; do timeout -k 1m 1h /usr/share/wallarm-common/sync-markers -l STDOUT || true; sleep 60; done"]
           volumeMounts:
           - mountPath: /etc/wallarm
             name: wallarm
+          resources:
+{{ toYaml .Values.controller.wallarm.sync-markers.resources | indent 12 }}
         - name: export-attacks
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
           command: ["sh", "-c", "while true; do timeout -k 1m 3h /usr/share/wallarm-common/export-attacks -l STDOUT || true; done"]
           volumeMounts:
           - mountPath: /etc/wallarm
             name: wallarm
+          resources:
+{{ toYaml .Values.controller.wallarm.export-attacks.resources | indent 12 }}
         - name: export-counters
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
           command: ["sh", "-c", "while true; do timeout -k 15s 11m /usr/share/wallarm-common/export-counters -l STDOUT || true; sleep 60; done"]
           volumeMounts:
           - mountPath: /etc/wallarm
             name: wallarm
+          resources:
+{{ toYaml .Values.controller.wallarm.export-counters.resources | indent 12 }}
         - name: export-clusterization-data
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
           command: ["sh", "-c", "while true; do timeout -k 15s 11m /usr/share/wallarm-common/export-clusterization-data -l STDOUT || true; sleep 60; done"]
           volumeMounts:
           - mountPath: /etc/wallarm
             name: wallarm
+          resources:
+{{ toYaml .Values.controller.wallarm.export-clusterization-data.resources | indent 12 }}
         - name: sync-brute-clusters
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
           command: ["sh", "-c", "while true; do timeout -k 15s 11m /usr/share/wallarm-common/sync-brute-clusters -l STDOUT || true; sleep 60; done"]
           volumeMounts:
           - mountPath: /etc/wallarm
             name: wallarm
+          resources:
+{{ toYaml .Values.controller.wallarm.sync-brute-clusters.resources | indent 12 }}
         - name: brute-detect
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
           command: ["sh", "-c", "while true; do timeout -k 15s 6m /usr/share/wallarm-common/brute-detect -l STDOUT || true; sleep 60; done"]
           volumeMounts:
           - mountPath: /etc/wallarm
             name: wallarm
+          resources:
+{{ toYaml .Values.controller.wallarm.brute-detect.resources | indent 12 }}
     {{- if .Values.controller.wallarm.tarantool.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.controller.wallarm.tarantool.nodeSelector | indent 8 }}

--- a/wallarm-ingress/values.yaml
+++ b/wallarm-ingress/values.yaml
@@ -431,6 +431,21 @@ controller:
         successThreshold: 1
         timeoutSeconds: 1
       resources: {}
+    heartbeat:
+      resources: {}
+    sync-markers:
+      resources: {}
+    export-attacks:
+      resources: {}
+    export-counters:
+      resources: {}
+    export-clusterization-data:
+      resources: {}
+    sync-brute-clusters:
+      resources: {}
+    brute-detect:
+      resources: {}
+
     metrics:
       enabled: false
 


### PR DESCRIPTION
Resources definitions for all containers containers in wallarm-tarantool pod was added  in `tarantool-deployment.yaml`
Fix #6 